### PR TITLE
Update ForwardDiff compat

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -14,7 +14,7 @@ PolyLogForwardDiffExt = "ForwardDiff"
 [compat]
 ChainRulesCore = "1"
 ChainRulesTestUtils = "1"
-ForwardDiff = "0.10,0.11"
+ForwardDiff = "0.10,0.11,1"
 julia = "1.0"
 
 [extras]


### PR DESCRIPTION
This PR just allows ForwardDiff v1 to be installed. the last ForwardDiff version does not have any changes that impact the current functionality of PolyLog derivatives.